### PR TITLE
Added support for an autoscaler cloud-init file.

### DIFF
--- a/autoscaler-cloudinit.yaml.jinja
+++ b/autoscaler-cloudinit.yaml.jinja
@@ -1,0 +1,2 @@
+#cloud-config
+{{ salt['pillar.get']('gitlab-runner:cloud-init', '') }}

--- a/pillar.example
+++ b/pillar.example
@@ -38,6 +38,12 @@ gitlab-runner:
   docker-machine: True
   # Override the systemd gitlab-runner.service unit timeout to 2h, if absent use systemd default timeout (90s)
   systemd-timeout-stop-sec: 7200
+  # If set a cloud-init file will be created, which can be used to configure autoscale VMs.
+  cloud-init: |
+    manage_resolv_conf: true
+    resolv_conf:
+      nameservers:
+        - 1.1.1.1
   # Deploy a preregistered config, note the runner SECRET_TOKEN generated as part of registration (use appropriate encryption).
   # This is necessarily a heavily redacted excerpt from a potentially vast config. Please consult official docs.
   config: |

--- a/runner.sls
+++ b/runner.sls
@@ -80,3 +80,14 @@ gitlab-runner:
         TimeoutStopSec={{ salt['pillar.get']('gitlab-runner:systemd-timeout-stop-sec') }}
         KillSignal=SIGQUIT
 {% endif %}
+
+{% if salt['pillar.get']('gitlab-runner:cloud-init', none) is not none %}
+# Deploy cloud-init file for autoscaling instances.
+/etc/gitlab-runner/autoscaler-cloudinit.yaml:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: 644
+    - template: jinja
+    - source: salt://{{ tpldir }}/autoscaler-cloudinit.yaml.jinja
+{% endif %}

--- a/runner.sls
+++ b/runner.sls
@@ -10,6 +10,15 @@
 #    executor = "docker+machine"
 #    ...
 #
+# To use the cloud-init created with the gitlab-runner.cloud-init pillar key, you need to set the
+# MachineOptions to use the cloud-init file based on your provider.
+#    [runners.machine]
+#       MachineDriver = "openstack"
+#       MachineOptions = ["openstack-user-data-file=/etc/gitlab-runner/autoscaler-cloudinit.yaml"]
+#
+#       MachineDriver = "amazonec2"
+#       MachineOptions = ["amazonec2-userdata=/etc/gitlab-runner/autoscaler-cloudinit.yaml"]
+#
 # See [https://github.com/chr4/salt-docker] for some useful substates to prepare the required
 # docker base setup. In particular see states
 #   - docker


### PR DESCRIPTION
When the `cloud-init' pillar is set, a cloud-init file is created. The content of the file is taken from the pillar.
The cloud-init file can be used to configure VMs created with the autoscaler.