### PR TITLE
Enable gpg signing for gitlab

### DIFF
--- a/init.sls
+++ b/init.sls
@@ -15,7 +15,7 @@ gitlab_repo:
 # Deploy signing_key.gpg if options are given in pillar.
 # Make sure it's not existent if not.
 {% if salt['pillar.get']('gitlab:gitaly:signing_key', None) != none %}
-/etc/gitlab/gitaly/signing_key.gpg:
+/etc/gitlab/gitaly-ui.key:
   file.managed:
     - user: root
     - group: root

--- a/init.sls
+++ b/init.sls
@@ -12,6 +12,19 @@ gitlab_repo:
 {{ edition }}:
   pkg.installed: []
 
+# Deploy signing_key.gpg if options are given in pillar.
+# Make sure it's not existent if not.
+{% if salt['pillar.get']('gitlab:gitaly:signing_key', None) != none %}
+/etc/gitlab/gitaly/signing_key.gpg:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: 600
+    - contents_pillar: gitlab:gitaly:signing_key
+    - require:
+      - pkg: {{ edition }}
+{% endif %}
+
 /etc/gitlab/gitlab.rb:
   file.managed:
     - user: root

--- a/pillar.example
+++ b/pillar.example
@@ -24,6 +24,15 @@ gitlab:
     # Change default theme to light
     gitlab_rails['gitlab_default_theme'] = 3
 
+    # Set gitaly signing key
+    gitaly['configuration'] = {
+      git: {
+        committer_name: 'GitLab',
+        committer_email: 'noreply@gitlab.example.com',
+        signing_key: '/etc/gitlab/gitaly-ui.key'
+      },
+    }
+
   registry:
     garbage_collect:
       # Delete manifests that are not currenetly referenced via tag

--- a/pillar.example
+++ b/pillar.example
@@ -43,8 +43,15 @@ gitlab:
       on_calendar: 02:00
 
   gitaly:
-    signing_key:
+    # SSH signing key
+    signing_key: 'ssh-ed25519 AAAA...'
+
+    # Alternatively using GPG
+    signing_key: |
+      -----BEGIN PGP PRIVATE KEY BLOCK-----
+
       ...
+      -----END PGP PRIVATE KEY BLOCK-----
 
 
 gitlab-runner:

--- a/pillar.example
+++ b/pillar.example
@@ -33,6 +33,11 @@ gitlab:
       # Run at a specific time, defaults to 02:00 every night
       on_calendar: 02:00
 
+  gitaly:
+    signing_key:
+      ...
+
+
 gitlab-runner:
   # Indicate that the cross-dependency to the docker salt formula is required; defaults to False
   docker-machine: True


### PR DESCRIPTION
Allows to add a key to sign automated commits in gitlab according to https://docs.gitlab.com/ee/administration/gitaly/configure_gitaly.html#configure-commit-signing-for-gitlab-ui-commits