### PR TITLE
Give gituser permissions to signing_key file

### DIFF
--- a/init.sls
+++ b/init.sls
@@ -17,7 +17,7 @@ gitlab_repo:
 {% if salt['pillar.get']('gitlab:gitaly:signing_key', None) != none %}
 /etc/gitlab/gitaly-ui.key:
   file.managed:
-    - user: root
+    - user: git
     - group: root
     - mode: 600
     - contents_pillar: gitlab:gitaly:signing_key


### PR DESCRIPTION
The `git` user needs permissions to the signing key file according to https://docs.gitlab.com/ee/administration/gitaly/configure_gitaly.html?tab=Linux+package+%28Omnibus%29#configure-gitaly-servers

Otherwise the file can't be read and we get an error:

```
failed to parse signing key: open file: open /etc/gitlab/gitaly-ui.key: permission denied
```